### PR TITLE
Document functions in Executor.hs

### DIFF
--- a/src/Executor.hs
+++ b/src/Executor.hs
@@ -5,6 +5,11 @@ module Executor
 import Parser
 import qualified Data.Map as Map
 
+-- |Interprets and executes the given wasm function using the given list of
+-- WasmVal parameters.
+-- If the parameter list does not match the required parameters of the function
+-- definition an error is thrown. Errors are also thrown if instructions in the
+-- function are not supported or lead to run-time errors.
 execFunc :: Func -> [WasmVal] -> [WasmVal]
 execFunc (Func name params block) vals =
   if (validParams params vals) then
@@ -14,6 +19,10 @@ execFunc (Func name params block) vals =
       ++ "the parameter types " ++ (show params) ++ " of function " ++ name
       ++ ".")
 
+-- |Returns a modification of the given WasmVal stack and execution
+-- environment by executing the instructions in the given block.
+-- An error might be thrown if instructions in the function are not supported or
+-- lead to run-time errors.
 execBlock :: Block -> [WasmVal] -> Map.Map String WasmVal ->
   ([WasmVal], Map.Map String WasmVal)
 execBlock (Block res []) stack locals = if validResults res (reverse stack)
@@ -24,24 +33,36 @@ execBlock (Block res (i:is)) stack locals =
   let update = execInstr i stack locals
   in  execBlock (Block res (is)) (fst update) (snd update)
 
+-- |Determines whether or not the given WasmVal stack matches a given parameter
+-- definition. Match checking is done using the valsOfType function.
 validParams :: [Param] -> [WasmVal] -> Bool
 validParams params vals =
   let types = map (\(Param _ typ) -> typ) params
   in valsOfType vals types
 
+-- |Determines whether or not the given WasmVal stack matches a given list of
+-- return values. Match checking is done using the valsOfType function.
 validResults :: [Result] -> [WasmVal] -> Bool
 validResults results vals =
   let types = map (\(Result typ) -> typ) results
   in valsOfType vals types
 
+-- |Checks if WasmVals in a list correspond with a list of WasmTypes. False is
+-- returned if the two lists differ in size.
 valsOfType :: [WasmVal] -> [WasmType] -> Bool
 valsOfType vals types =
   let zipped = zipWith ofType vals types
   in (length types) == (length vals) && (foldl (&&) True zipped)
 
+-- |Throws an error with the message prefixed with "TypeError: ".
 typeError :: String -> a
 typeError message = error ("TypeError: " ++ message)
 
+-- |Returns a modification of the given WasmVal stack and execution environment
+-- by executing the given Instr in the given block as if it were an actual
+-- wasm instruction.
+-- Throws an error if there is no implementation for the given Instr or if the
+-- Instr cannot be executed on this given environment.
 execInstr :: Instr -> [WasmVal] -> Map.Map String WasmVal ->
   ([WasmVal], Map.Map String WasmVal)
 execInstr (EnterBlock block) stack locals = execBlock block stack locals
@@ -66,13 +87,17 @@ execInstr (Numeric (Div typ Signed)) (x:y:stack) locals =
 execInstr Nop stack locals = (stack, locals)
 execInstr instr _ _ = error ("Couldn't evaluate " ++ (show instr) ++ ".")
 
+-- |Defines wasm I32 values as "falsy" if equal to 0 and "truthy" otherwise.
+-- Throws an error if a value of any other type than I32 is given.
 valToBool :: WasmVal -> Bool
 valToBool val = case val of
-  I32Val x -> x > 0
-  I64Val x -> x > 0
-  F32Val _ -> typeError "F32 type cannot be evaluated as a boolean."
-  F64Val _ -> typeError "F64 type cannot be evaluated as a boolean."
+  I32Val x -> x /= 0
+  val -> typeError ((show val) ++ " cannot be evaluated as a boolean.")
 
+-- |Evaluates an expression of two WasmVals and a numeric binary operator and
+-- returns the resulting WasmVal.
+-- Throws an error if the operation and of the WasmVals aren't all of the same
+-- type.
 binOp :: WasmType -> WasmVal -> WasmVal -> (Integer -> Integer -> Integer) ->
   (Double -> Double -> Double) -> WasmVal
 binOp typ x y opI opF = if not (x `ofType` typ && y `ofType` typ)


### PR DESCRIPTION
Small pull-req in which I added some documentation to the functions in Executor.hs (Closes #20). I also modified the valToBool definition to make it correctly mimic wasm's way of making booleans out of i32's. 