### PR TITLE
Replace regex-pcre with regex-pcre-builtin

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ library:
   dependencies:
     - containers
     - regex-compat
-    - regex-pcre
+    - regex-pcre-builtin
 
 executables:
   sturdy-wasm-exe:


### PR DESCRIPTION
Replaces the dependency "regex-pcre" with "regex-pcre-builtin" to make it also work on Windows. This should not affect the behavior of the program.