### PR TITLE
Executor exceptions

### DIFF
--- a/src/Executor.hs
+++ b/src/Executor.hs
@@ -12,6 +12,8 @@ import qualified Control.Exception as E
 data ExecutorException
     = TypeError String          -- ^For failed type matching.
     | LookupError String        -- ^For variable lookup errors.
+    | WasmArithError String     -- ^For arithmetic errors that would have been
+                                --  runtime errors in WASM (like div by zero).
     | NotImplemented Instr      -- ^For unimplemented instruction.
     deriving Show
 
@@ -19,7 +21,7 @@ instance E.Exception ExecutorException
 
 -- |Catches ExecutorExceptions by using the given handler function that are
 --  possible thrown by the given expression.
-executorCatch :: (ExecutorException -> IO a) -> a -> IO a
+executorCatch :: (ExecutorException  -> IO a) -> a -> IO a
 executorCatch handler x = E.catch (E.evaluate x) handler
 
 -- |Interprets and executes the given wasm function using the given list of

--- a/src/Executor.hs
+++ b/src/Executor.hs
@@ -1,111 +1,122 @@
 module Executor
   ( execFunc
+  , ExecutorException(..)
+  , executorCatch
   ) where
 
 import Parser
 import qualified Data.Map as Map
+import qualified Control.Exception as E
+
+-- |All exceptions that can be thrown by the executor.
+data ExecutorException
+    = TypeError String          -- ^For failed type matching.
+    | LookupError String        -- ^For variable lookup errors.
+    | NotImplemented Instr      -- ^For unimplemented instruction.
+    deriving Show
+
+instance E.Exception ExecutorException
+
+-- |Catches ExecutorExceptions by using the given handler function that are
+--  possible thrown by the given expression.
+executorCatch :: (ExecutorException -> IO a) -> a -> IO a
+executorCatch handler x = E.catch (E.evaluate x) handler
 
 -- |Interprets and executes the given wasm function using the given list of
--- WasmVal parameters.
--- If the parameter list does not match the required parameters of the function
--- definition an error is thrown. Errors are also thrown if instructions in the
--- function are not supported or lead to run-time errors.
+--  WasmVal parameters.
+--  If the parameter list does not match the required parameters of the function
+--  definition a TypeError is thrown. ExecutorExceptions are also thrown if
+--  instructions in the function are not supported or lead to run-time errors.
 execFunc :: Func -> [WasmVal] -> [WasmVal]
 execFunc (Func name params block) vals =
-  if (validParams params vals) then
-    let kvPairs = zipWith (\(Param name _) x -> (name, x)) params vals
-    in fst (execBlock block [] (Map.fromList kvPairs))
-    else error ("Type error: given stack " ++ (show vals) ++ " does not match "
-      ++ "the parameter types " ++ (show params) ++ " of function " ++ name
-      ++ ".")
+    if (validParams params vals) then
+        let kvPairs = zipWith (\(Param name _) x -> (name, x)) params vals
+        in fst (execBlock block [] (Map.fromList kvPairs))
+        else E.throw (TypeError $ (show vals) ++ " stack does not match params "
+            ++ (show params) ++ " of func " ++ name ++ ".")
 
 -- |Returns a modification of the given WasmVal stack and execution
--- environment by executing the instructions in the given block.
--- An error might be thrown if instructions in the function are not supported or
--- lead to run-time errors.
+--  environment by executing the instructions in the given block.
+--  An ExecutorException might be thrown if instructions in the function are not
+--  supported or lead to run-time errors.
 execBlock :: Block -> [WasmVal] -> Map.Map String WasmVal ->
-  ([WasmVal], Map.Map String WasmVal)
+    ([WasmVal], Map.Map String WasmVal)
 execBlock (Block res []) stack locals = if validResults res (reverse stack)
-  then (reverse stack, locals) else
-    error ("Type error: resulting stack " ++ (show stack) ++ " does not "
-      ++ "match result types " ++ (show res) ++ " of the block.")
+    then (reverse stack, locals) else E.throw (TypeError $ (show stack)
+        ++ " stack does not match results " ++ (show res) ++ " of block.")
 execBlock (Block res (i:is)) stack locals =
-  let update = execInstr i stack locals
-  in  execBlock (Block res (is)) (fst update) (snd update)
+    let update = execInstr i stack locals
+    in  execBlock (Block res (is)) (fst update) (snd update)
 
 -- |Determines whether or not the given WasmVal stack matches a given parameter
--- definition. Match checking is done using the valsOfType function.
+--  definition. Match checking is done using the valsOfType function.
 validParams :: [Param] -> [WasmVal] -> Bool
 validParams params vals =
-  let types = map (\(Param _ typ) -> typ) params
-  in valsOfType vals types
+    let types = map (\(Param _ typ) -> typ) params
+    in valsOfType vals types
 
 -- |Determines whether or not the given WasmVal stack matches a given list of
--- return values. Match checking is done using the valsOfType function.
+--  return values. Match checking is done using the valsOfType function.
 validResults :: [Result] -> [WasmVal] -> Bool
 validResults results vals =
-  let types = map (\(Result typ) -> typ) results
-  in valsOfType vals types
+    let types = map (\(Result typ) -> typ) results
+    in valsOfType vals types
 
 -- |Checks if WasmVals in a list correspond with a list of WasmTypes. False is
--- returned if the two lists differ in size.
+--  returned if the two lists differ in size.
 valsOfType :: [WasmVal] -> [WasmType] -> Bool
 valsOfType vals types =
-  let zipped = zipWith ofType vals types
-  in (length types) == (length vals) && (foldl (&&) True zipped)
-
--- |Throws an error with the message prefixed with "TypeError: ".
-typeError :: String -> a
-typeError message = error ("TypeError: " ++ message)
+    let zipped = zipWith ofType vals types
+    in (length types) == (length vals) && (foldl (&&) True zipped)
 
 -- |Returns a modification of the given WasmVal stack and execution environment
--- by executing the given Instr in the given block as if it were an actual
--- wasm instruction.
--- Throws an error if there is no implementation for the given Instr or if the
--- Instr cannot be executed on this given environment.
+--  by executing the given Instr in the given block as if it were an actual
+--  wasm instruction.
+--  Throws a NotImplemented if there is no implementation for the given Instr.
+--  Throws a LookupError if the Instr cannot be executed within this
+--  environment.
 execInstr :: Instr -> [WasmVal] -> Map.Map String WasmVal ->
-  ([WasmVal], Map.Map String WasmVal)
+    ([WasmVal], Map.Map String WasmVal)
 execInstr (EnterBlock block) stack locals = execBlock block stack locals
 execInstr (If instr) (x:stack) locals = if valToBool x
-  then execInstr instr stack locals else (stack, locals)
+    then execInstr instr stack locals else (stack, locals)
 execInstr (LocalGet tag) stack locals = case Map.lookup tag locals of
-  Just val -> (val:stack, locals)
-  Nothing -> error ("No local variable in scope with tag \"" ++ tag ++ "\".")
+    Just val -> (val:stack, locals)
+    Nothing -> E.throw (LookupError $ "on local var \"" ++ tag ++ "\".")
 execInstr (LocalSet tag) (x:stack) locals = (stack, Map.insert tag x locals)
 execInstr (LocalTee tag) stack locals =
-  let whenSet = execInstr (LocalSet tag) stack locals
-  in  execInstr (LocalGet tag) (fst whenSet) (snd whenSet)
+    let whenSet = execInstr (LocalSet tag) stack locals
+    in  execInstr (LocalGet tag) (fst whenSet) (snd whenSet)
 execInstr (Numeric (Const val)) stack locals = (val:stack, locals)
 execInstr (Numeric (Add typ)) (x:y:stack) locals =
-  ((binOp typ y x (+) (+)):stack, locals)
+    ((binOp typ y x (+) (+)):stack, locals)
 execInstr (Numeric (Sub typ)) (x:y:stack) locals =
-  ((binOp typ y x (-) (-)):stack, locals)
+    ((binOp typ y x (-) (-)):stack, locals)
 execInstr (Numeric (Mul typ)) (x:y:stack) locals =
-  ((binOp typ y x (*) (*)):stack, locals)
+    ((binOp typ y x (*) (*)):stack, locals)
 execInstr (Numeric (Div typ Signed)) (x:y:stack) locals =
-  ((binOp typ y x div (/)):stack, locals)
+    ((binOp typ y x div (/)):stack, locals)
 execInstr Nop stack locals = (stack, locals)
-execInstr instr _ _ = error ("Couldn't evaluate " ++ (show instr) ++ ".")
+execInstr instr _ _ = E.throw $ NotImplemented instr
 
 -- |Defines wasm I32 values as "falsy" if equal to 0 and "truthy" otherwise.
--- Throws an error if a value of any other type than I32 is given.
+--  Throws a TypeError if a value of any other type than I32 is given.
 valToBool :: WasmVal -> Bool
 valToBool val = case val of
-  I32Val x -> x /= 0
-  val -> typeError ((show val) ++ " cannot be evaluated as a boolean.")
+    I32Val x -> x /= 0
+    val -> E.throw (TypeError $ (show val) ++ " cannot be evaluated to Bool.")
 
 -- |Evaluates an expression of two WasmVals and a numeric binary operator and
--- returns the resulting WasmVal.
--- Throws an error if the operation and of the WasmVals aren't all of the same
--- type.
+--  returns the resulting WasmVal.
+--  Throws a TypeError if the operation and of the WasmVals aren't all of the
+--  same type.
 binOp :: WasmType -> WasmVal -> WasmVal -> (Integer -> Integer -> Integer) ->
-  (Double -> Double -> Double) -> WasmVal
+    (Double -> Double -> Double) -> WasmVal
 binOp typ x y opI opF = if not (x `ofType` typ && y `ofType` typ)
-  then typeError ("binary operation type does not match the types of its "
-    ++ "arguments.")
-  else case (x, y) of
-    (I32Val a, I32Val b) -> I32Val (a `opI` b)
-    (I64Val a, I64Val b) -> I64Val (a `opI` b)
-    (F32Val a, F32Val b) -> F32Val (a `opF` b)
-    (F64Val a, F64Val b) -> F64Val (a `opF` b)
-    (_, _) -> typeError "binary operation on two different types."
+    then E.throw (TypeError "binOp type does not match the types of its args.")
+    else case (x, y) of
+        (I32Val a, I32Val b) -> I32Val (a `opI` b)
+        (I64Val a, I64Val b) -> I64Val (a `opI` b)
+        (F32Val a, F32Val b) -> F32Val (a `opF` b)
+        (F64Val a, F64Val b) -> F64Val (a `opF` b)
+        (_, _) -> E.throw (TypeError "binOp on two different types.")

--- a/src/Lexer.hs
+++ b/src/Lexer.hs
@@ -9,7 +9,7 @@ import Text.Regex.PCRE
 import Tokens
 
 
-data Tokenizable a 
+data Tokenizable a
     = CompleteToken a
     | IncompleteToken a
     deriving (Show, Eq)
@@ -25,11 +25,11 @@ tokenizeS str = case str of
     ")" -> RP
     _ -> tokenizeStringHelper str
 
--- Helper functions -- 
+-- Helper functions --
 
 -- | tokenizeSyma stream of tokens [Note: Can be improved].
 tokenizeStream :: String -> (String, [Token]) -> (String, [Token])
-tokenizeStream str (mem, tokens) 
+tokenizeStream str (mem, tokens)
     | str == [] = case mem of
         [] -> ("", tokens)
         _ -> ("", tokenizeS (trim mem) : tokens)
@@ -52,7 +52,7 @@ isCompleteToken (IncompleteToken _) = False
 
 -- | Find out if the character will complete the token.
 findToken :: Char -> String -> Tokenizable String
-findToken char str 
+findToken char str
     | char == '(' || char == ')' = CompleteToken str
     | [char] =~ "\\s" && str /= "" = CompleteToken str
     | [char] =~ "\\s" && str == "" = IncompleteToken str
@@ -60,7 +60,7 @@ findToken char str
 
 -- | Trim whitespaces from the strings that will be tokenized
 trim :: String -> String
-trim str 
+trim str
     | str == "" = ""
     | [last str]  =~ "\\s" = trim $ init str
     | [head str]  =~ "\\s" = trim $ tail str
@@ -75,7 +75,7 @@ tokenizeSym(CompleteToken str) = case str of
     "(" -> LP
     ")" -> RP
     _ -> tokenizeStringHelper str
-    
+
 tokenizeStringHelper :: String -> Token
 tokenizeStringHelper str
     | head str == '$' = ID $ drop 1 str

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -122,7 +122,7 @@ instance MonadPlus Parser where
 
 instance Alternative Parser where
   empty  = mzero
-  p <|> q = Parser(\s -> 
+  p <|> q = Parser(\s ->
     case parse p s of
       []  -> parse q s
       res -> res)
@@ -133,10 +133,10 @@ item = Parser (\cs -> case cs of
   (c:cs) -> [(c,cs)])
 
 sat  :: (Token -> Bool) -> Parser Token
-sat p = do 
+sat p = do
   c <- item
-  if p c 
-    then return c 
+  if p c
+    then return c
     else mzero
 
 {-

--- a/test/unit/ExecutorSpec.hs
+++ b/test/unit/ExecutorSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec
 import Generators
 import Parser
 import Executor
-import Control.Exception.Base
+import qualified Control.Exception as E
 
 -- Test suites --
 
@@ -19,11 +19,11 @@ tsExecFunc :: Spec
 tsExecFunc = describe "execFunc" $ do
     testExecFunc
     testExecAddition
-    testExecSubstraction
+    testExecSubtraction
     testExecMultiplication
+    testExecFuncInvalidParams
     --testExecDivision
     --testExecDivByZero
-    
 
 -- Tests --
 foo = Func "foo" [Param "a" I32, Param "b" I32, Param "c" I32,
@@ -37,7 +37,7 @@ foo = Func "foo" [Param "a" I32, Param "b" I32, Param "c" I32,
     Numeric (Sub I32)
     ])
 
-testExecFunc = it "Test some function with multiple math operators" $ 
+testExecFunc = it "Test some function with multiple math operators" $
     execFunc foo [I32Val 8, I32Val 2, I32Val 5, I32Val 7] `shouldBe` [I32Val (-31)]
 
 addition = Func "add" [Param "a" I32, Param "b" I32]
@@ -50,15 +50,15 @@ addition = Func "add" [Param "a" I32, Param "b" I32]
 testExecAddition = it "Test addition with 2 values" $
     property $ \(x,y) -> execFunc addition [I32Val (x::Integer), I32Val (y::Integer)] `shouldBe` [I32Val (x+y)]
 
-substraction = Func "sub" [Param "a" I32, Param "b" I32]
+subtraction = Func "sub" [Param "a" I32, Param "b" I32]
     (Block [Result I32] [
         LocalGet "a",
         LocalGet "b",
         Numeric (Sub I32)
     ])
 
-testExecSubstraction = it "Test substraction with 2 values" $
-    property $ \(x,y) -> execFunc substraction [I32Val (x::Integer), I32Val (y::Integer)] `shouldBe` [I32Val (x-y)]
+testExecSubtraction = it "Test subtraction with 2 values" $
+    property $ \(x,y) -> execFunc subtraction [I32Val (x::Integer), I32Val (y::Integer)] `shouldBe` [I32Val (x-y)]
 
 multiplication = Func "mul" [Param "a" I32, Param "b" I32]
     (Block [Result I32] [
@@ -82,5 +82,7 @@ division = Func "div" [Param "a" I32, Param "b" I32]
 testExecDivision = it "Test division with 2 values" $
     forAll arbitrary $ \x -> forAll genNonZero $ \y -> execFunc division [I32Val x, I32Val y] `shouldBe` [I32Val (quot x y)]
 
+testExecFuncInvalidParams = it "Test addition with insufficient parameters" $
+    forAll arbitrary $ \x -> E.evaluate (execFunc addition [I32Val (x::Integer)]) `shouldThrow` anyException
 --testExecDivByZero = it "Test division by 0" $
 --   property $ \x -> execFunc division [I32Val (x::Integer), I32Val 0] `shouldThrow` DivideByZero

--- a/test/unit/ExecutorSpec.hs
+++ b/test/unit/ExecutorSpec.hs
@@ -22,8 +22,26 @@ tsExecFunc = describe "execFunc" $ do
     testExecSubtraction
     testExecMultiplication
     testExecFuncInvalidParams
+    testCatchNoError
+    testCatchWithError
+    testExecFaultyIf
+    testExecLookupErrorCode
     --testExecDivision
     --testExecDivByZero
+
+-- Exception types --
+
+typeError :: Selector ExecutorException
+typeError (TypeError _) = True
+typeError _ = False
+
+lookupError :: Selector ExecutorException
+lookupError (LookupError _) = True
+lookUpError _ = False
+
+wasmArithError :: Selector ExecutorException
+wasmArithError (WasmArithError _) = True
+wasmArithError _ = False
 
 -- Tests --
 foo = Func "foo" [Param "a" I32, Param "b" I32, Param "c" I32,
@@ -82,7 +100,32 @@ division = Func "div" [Param "a" I32, Param "b" I32]
 testExecDivision = it "Test division with 2 values" $
     forAll arbitrary $ \x -> forAll genNonZero $ \y -> execFunc division [I32Val x, I32Val y] `shouldBe` [I32Val (quot x y)]
 
+testCatchNoError = it "Test executorCatch on correct wasm code" $
+    forAll arbitrary $ \(x, y) -> executorCatch (\_ -> return [I32Val (-1)])
+        (execFunc addition [I32Val (x::Integer), I32Val (y::Integer)]) `shouldReturn` [I32Val (x + y)]
+
+testCatchWithError = it "Test executorCatch on wasm code with insufficient parameters" $
+    forAll arbitrary $ \x -> executorCatch (\_ -> return [I32Val (-1)])
+        (execFunc addition [I32Val (x::Integer)]) `shouldReturn` [I32Val (-1)]
+
 testExecFuncInvalidParams = it "Test addition with insufficient parameters" $
-    forAll arbitrary $ \x -> E.evaluate (execFunc addition [I32Val (x::Integer)]) `shouldThrow` anyException
+    forAll arbitrary $ \x -> E.evaluate (execFunc addition [I32Val (x::Integer)]) `shouldThrow` typeError
+
+faultyIf = Func "if" [Param "a" I64]
+    (Block [Result I64] [
+        LocalGet "a",
+        If (LocalGet "a")
+    ])
+
+testExecFaultyIf = it "Expect a TypeError when executing a wasm if-statement with no I32Val on top of the stack" $
+    property $ \x -> E.evaluate (execFunc faultyIf [I64Val (x::Integer)]) `shouldThrow` typeError
+
+lookupErrorCode = Func "lookup" []
+    (Block [Result F32] [
+        LocalGet "a"
+    ])
+
+testExecLookupErrorCode = it "Test a LookupError when fetching a non-existing local variable" $
+    E.evaluate (execFunc lookupErrorCode []) `shouldThrow` lookupError
 --testExecDivByZero = it "Test division by 0" $
 --   property $ \x -> execFunc division [I32Val (x::Integer), I32Val 0] `shouldThrow` DivideByZero


### PR DESCRIPTION
Close #9 . This replaces the `error` calls with exception throws in the Executor functions using the module `Control.Exception`.