### PR TITLE
Executor environment

### DIFF
--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -4,6 +4,7 @@ module Environment
   , Environment(..)
   , emptyEnv
   , setStack
+  , clearStack
   , stackHead
   , stackTail
   , stackPush
@@ -22,43 +23,62 @@ import qualified Data.Map as M
 type Stack = [WasmVal]
 type WasmValMap = M.Map String WasmVal
 
-data Environment = Environment { stack :: Stack
-                             , loc :: WasmValMap
-                             , glob :: WasmValMap
-                             } deriving (Show, Eq)
+-- |Defines an execution environment for functions in Executor.hs.
+data Environment = Environment
+    { stack :: Stack            -- ^The stack containing WasmVals.
+    , loc :: WasmValMap         -- ^A map of all local variables in scope.
+    , glob :: WasmValMap        -- ^A map of all global variables.
+    } deriving (Show, Eq)
 
+-- |An empty environment
 emptyEnv :: Environment
 emptyEnv = Environment [] M.empty M.empty
 
+-- |Substitute the given Stack into the Environment.
 setStack :: Stack -> Environment -> Environment
 setStack s (Environment _ l g) = Environment s l g
 
+-- |Replace the Stack of the Environment with an empty list.
+clearStack :: Environment -> Environment
+clearStack = setStack []
+
+-- |Return the head of the Stack of the Environment.
 stackHead :: Environment -> WasmVal
 stackHead env = head (stack env)
 
+-- |Return the tail of the Stack of the Environment.
 stackTail :: Environment -> [WasmVal]
 stackTail env = tail (stack env)
 
+-- |Put the given WasmVal in on top of the Stack of the Environment.
 stackPush :: WasmVal -> Environment -> Environment
 stackPush x env = setStack (x:(stack env)) env
 
+-- |Remove n elements from the top of the Stack of the Environment.
 stackPopN :: Int -> Environment -> Environment
 stackPopN n env = setStack (drop n (stack env)) env
 
+-- |Remove one element from the top of the Stack of the Environment.
 stackPop :: Environment -> Environment
 stackPop = stackPopN 1
 
+-- |Create an Environment with the given Stack. All other fields are initialized
+--  as defined in emptyEnv.
 fromStack :: Stack -> Environment
 fromStack s = setStack s emptyEnv
 
+-- |Substitute the given WasmValMap as local variables into the Environment.
 setLoc :: WasmValMap -> Environment -> Environment
 setLoc l (Environment s _ g) = Environment s l g
 
+-- |Replace the local variables in the Environment with an empty Map.
 clearLoc :: Environment -> Environment
 clearLoc = setLoc M.empty
 
+-- |Bind a WasmVal to a tag in the Environment.
 insertLoc :: String -> WasmVal -> Environment -> Environment
 insertLoc tag x env = setLoc (M.insert tag x (loc env)) env
 
+-- |Substitute the given WasmValMap as global variables into the Environment.
 setGlob :: Environment -> WasmValMap -> Environment
 setGlob (Environment s l _) g = Environment s l g

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -1,0 +1,64 @@
+module Environment
+  ( Stack
+  , WasmValMap
+  , Environment(..)
+  , emptyEnv
+  , setStack
+  , stackHead
+  , stackTail
+  , stackPush
+  , stackPopN
+  , stackPop
+  , fromStack
+  , setLoc
+  , clearLoc
+  , insertLoc
+  , setGlob
+  ) where
+
+import Parser
+import qualified Data.Map as M
+
+type Stack = [WasmVal]
+type WasmValMap = M.Map String WasmVal
+
+data Environment = Environment { stack :: Stack
+                             , loc :: WasmValMap
+                             , glob :: WasmValMap
+                             } deriving (Show, Eq)
+
+emptyEnv :: Environment
+emptyEnv = Environment [] M.empty M.empty
+
+setStack :: Environment -> Stack -> Environment
+setStack (Environment _ l g) s = Environment s l g
+
+stackHead :: Environment -> WasmVal
+stackHead env = head (stack env)
+
+stackTail :: Environment -> [WasmVal]
+stackTail env = tail (stack env)
+
+stackPush :: Environment -> WasmVal -> Environment
+stackPush env x = setStack env (x:(stack env))
+
+stackPopN :: Int -> Environment -> Environment
+stackPopN n env = setStack env (drop n (stack env))
+
+stackPop :: Environment -> Environment
+stackPop = stackPopN 1
+
+fromStack :: Stack -> Environment
+fromStack s = setStack emptyEnv s
+
+setLoc :: Environment -> WasmValMap -> Environment
+setLoc (Environment s _ g) l = Environment s l g
+
+clearLoc :: Environment -> Environment
+clearLoc (Environment s l g) = Environment s M.empty g
+
+insertLoc :: Environment -> String -> WasmVal -> Environment
+insertLoc (Environment s l g) tag x = Environment s (M.insert tag x l) g
+
+setGlob :: Environment -> WasmValMap -> Environment
+setGlob (Environment s l _) g = Environment s l g

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -30,8 +30,8 @@ data Environment = Environment { stack :: Stack
 emptyEnv :: Environment
 emptyEnv = Environment [] M.empty M.empty
 
-setStack :: Environment -> Stack -> Environment
-setStack (Environment _ l g) s = Environment s l g
+setStack :: Stack -> Environment -> Environment
+setStack s (Environment _ l g) = Environment s l g
 
 stackHead :: Environment -> WasmVal
 stackHead env = head (stack env)
@@ -39,26 +39,26 @@ stackHead env = head (stack env)
 stackTail :: Environment -> [WasmVal]
 stackTail env = tail (stack env)
 
-stackPush :: Environment -> WasmVal -> Environment
-stackPush env x = setStack env (x:(stack env))
+stackPush :: WasmVal -> Environment -> Environment
+stackPush x env = setStack (x:(stack env)) env
 
 stackPopN :: Int -> Environment -> Environment
-stackPopN n env = setStack env (drop n (stack env))
+stackPopN n env = setStack (drop n (stack env)) env
 
 stackPop :: Environment -> Environment
 stackPop = stackPopN 1
 
 fromStack :: Stack -> Environment
-fromStack s = setStack emptyEnv s
+fromStack s = setStack s emptyEnv
 
-setLoc :: Environment -> WasmValMap -> Environment
-setLoc (Environment s _ g) l = Environment s l g
+setLoc :: WasmValMap -> Environment -> Environment
+setLoc l (Environment s _ g) = Environment s l g
 
 clearLoc :: Environment -> Environment
-clearLoc (Environment s l g) = Environment s M.empty g
+clearLoc = setLoc M.empty
 
-insertLoc :: Environment -> String -> WasmVal -> Environment
-insertLoc (Environment s l g) tag x = Environment s (M.insert tag x l) g
+insertLoc :: String -> WasmVal -> Environment -> Environment
+insertLoc tag x env = setLoc (M.insert tag x (loc env)) env
 
 setGlob :: Environment -> WasmValMap -> Environment
 setGlob (Environment s l _) g = Environment s l g

--- a/test/integration/SystemSpec.hs
+++ b/test/integration/SystemSpec.hs
@@ -5,6 +5,7 @@ import Test.Hspec
 import Lexer
 import Parser
 import Executor
+import Environment
 
 -- Test suites --
 spec :: Spec
@@ -18,7 +19,7 @@ tsFunctions = describe "functions" $ do
     testSimpleAddition
 
 
--- Tests --  
+-- Tests --
 
 programAdd = "(func $add (param $a i32) (param $b i32) \n\
                 \(result i32)\n\
@@ -29,5 +30,5 @@ programAdd = "(func $add (param $a i32) (param $b i32) \n\
 functionAdd = fst $ head $ parse Parser.function (tokenize programAdd)
 
 testSimpleAddition = it "Parse a function which does addition" $
-    property $ \(x,y) -> execFunc functionAdd [I32Val (x::Integer), I32Val (y::Integer)] `shouldBe` [I32Val (x+y)]
-     
+    property $ \(x,y) -> execFunc functionAdd (fromStack [I32Val (x::Integer), I32Val (y::Integer)])
+        `shouldBe` (fromStack [I32Val (x+y)])


### PR DESCRIPTION
Replace all ([WasmVal], Map) tuples in the function definitions of `Executor.hs` with a new `Environment` data type. `Environment` is defined in `Environment.hs` together with some utility functions.