### PR TITLE
Add support for local variables in validation

### DIFF
--- a/src/Validator.hs
+++ b/src/Validator.hs
@@ -249,7 +249,6 @@ checkM e = case e of
     LocalTee name -> do
         t <- getLocal <=< getLocalIndex $ name
         peekM $ Actual t
-        pushM $ Actual t
 
     Loop t ops' -> do
         checkLabel [] t ops'

--- a/src/Validator.hs
+++ b/src/Validator.hs
@@ -136,6 +136,10 @@ popM expected = Env $ \ctx -> do
     (r, ctx') <- popOp expected ctx
     return (r, ctx')
 
+-- | Checks if the current value matches the expected value 
+peekM :: InferType -> M ()
+peekM expected = popM expected >> pushM expected
+
 -- | Push control frame with given type signature
 pushCtrlM :: [ValType] -> [ValType] -> M ()
 pushCtrlM labels results = Env $ \ctx -> Right ((), pushCtrl labels results ctx)
@@ -244,9 +248,8 @@ checkM e = case e of
 
     LocalTee name -> do
         t <- getLocal <=< getLocalIndex $ name
-        popM $ Actual t
+        peekM $ Actual t
         pushM $ Actual t
-        -- ^ TODO make peek function to avoid duplication
 
     Loop t ops' -> do
         checkLabel [] t ops'

--- a/test/unit/ValidatorSpec.hs
+++ b/test/unit/ValidatorSpec.hs
@@ -17,6 +17,7 @@ spec = do
     blocks
     branching
     control
+    local
 
 basic = describe "basic" $ do
     testSimpleFunction
@@ -41,6 +42,10 @@ control = describe "control" $ do
     testInvalidIfBranch
     testValidLoop
     testValidInfiniteLoop
+
+local = describe "locals" $ do
+    testGetLocal
+    testSetLocal
 
 testSimpleFunction = do
     let fn = Func "" [] [Result I32] [Const (I32Val 1), Const (I32Val 1), Binary I32 Add]
@@ -121,6 +126,21 @@ testValidInfiniteLoop = do
     let fn = Func "" [] [Result I32] [Loop [I32] [Const (F32Val 0), Br 0, Const (I32Val 1)]]
     it "Infinite loop with correct result should validate correctly" $
         eval (checkFunc fn) `shouldBe` True
+
+testGetLocal = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [LocalGet "foo"]
+    it "Getting existing local should validate correctly" $
+        eval (checkFunc fn) `shouldBe` True
+
+testSetLocal = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 0), LocalSet "foo", LocalGet "foo"]
+    it "Setting correct local type should validate correctly" $
+        eval (checkFunc fn) `shouldBe` True
+
+testInvalodSetLocal = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I64Val 0), LocalSet "foo", LocalGet "foo"]
+    it "Setting incorrect local type should fail" $
+        eval (checkFunc fn) `shouldBe` False
 
 -- test = do
 --     let fn = 

--- a/test/unit/ValidatorSpec.hs
+++ b/test/unit/ValidatorSpec.hs
@@ -143,7 +143,7 @@ testSetLocal = do
         eval (checkFunc fn) `shouldBe` True
 
 testLocalTee = do
-    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 2), LocalTee "foo", Binary I32 Add]
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 2), LocalTee "foo"]
     it "Local tee should validate correctly" $
         eval (checkFunc fn) `shouldBe` True
 

--- a/test/unit/ValidatorSpec.hs
+++ b/test/unit/ValidatorSpec.hs
@@ -45,12 +45,14 @@ control = describe "control" $ do
 
 local = describe "locals" $ do
     testGetLocal
-    testSetLocal
-    testLocalTee
-    testLocalSetEmptyStack
     testScopedGetLocal
     testGetLocalIncorrectType
     testGetLocalBinary
+    testSetLocal
+    testInvalidSetLocal
+    testLocalSetEmptyStack
+    testLocalTee
+    testLocalTeeEmptyStack
 
 testSimpleFunction = do
     let fn = Func "" [] [Result I32] [Const (I32Val 1), Const (I32Val 1), Binary I32 Add]
@@ -137,26 +139,6 @@ testGetLocal = do
     it "Getting existing local should validate correctly" $
         eval (checkFunc fn) `shouldBe` True
 
-testSetLocal = do
-    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 0), LocalSet "foo", LocalGet "foo"]
-    it "Setting correct local type should validate correctly" $
-        eval (checkFunc fn) `shouldBe` True
-
-testLocalTee = do
-    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 2), LocalTee "foo"]
-    it "Local tee should validate correctly" $
-        eval (checkFunc fn) `shouldBe` True
-
-testInvalidSetLocal = do
-    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I64Val 0), LocalSet "foo", LocalGet "foo"]
-    it "Setting incorrect local type should fail" $
-        eval (checkFunc fn) `shouldBe` False
-
-testLocalSetEmptyStack = do
-    let fn = Func "" [Param "foo" I32] [Result I32] [LocalSet "foo", Const (I32Val 0), Br 0]
-    it "Local set with no value on stack should fail" $
-        eval (checkFunc fn) `shouldBe` False
-
 testScopedGetLocal = do
     let fn = Func "" [Param "foo" I32] [Result I32] [Block [I32] [Block [I32] [LocalGet "foo"]]]
     it "Getting existing local from inside block should validate correctly" $
@@ -171,3 +153,28 @@ testGetLocalBinary = do
     let fn = Func "" [Param "foo" I32] [Result I32] [LocalGet "foo", LocalGet "foo", Binary I32 Add]
     it "Adding same value should validate correctly" $
         eval (checkFunc fn) `shouldBe` True
+
+testSetLocal = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 0), LocalSet "foo", LocalGet "foo"]
+    it "Setting correct local type should validate correctly" $
+        eval (checkFunc fn) `shouldBe` True
+
+testInvalidSetLocal = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I64Val 0), LocalSet "foo", LocalGet "foo"]
+    it "Setting incorrect local type should fail" $
+        eval (checkFunc fn) `shouldBe` False
+
+testLocalSetEmptyStack = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [LocalSet "foo", Const (I32Val 0), Br 0]
+    it "Local set with no value on stack should fail" $
+        eval (checkFunc fn) `shouldBe` False
+
+testLocalTee = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [Const (I32Val 2), LocalTee "foo"]
+    it "Local tee should validate correctly" $
+        eval (checkFunc fn) `shouldBe` True
+
+testLocalTeeEmptyStack = do
+    let fn = Func "" [Param "foo" I32] [Result I32] [LocalTee "foo", Const (I32Val 0), Br 0]
+    it "Local tee with no value on stack should fail" $
+        eval (checkFunc fn) `shouldBe` False


### PR DESCRIPTION
Add support for local.get, local.set and local.tee  

Currently uses a list of strings as a mapping of variable name to value type. A list is used as opposed to Data.Map because variables are indexed relatively (e.g. local.get 0), so using a Map would require a secondary data structure to store the relative index of each variable.

In the spec, the variable names get desugared into indices ([spec#contexts](https://webassembly.github.io/spec/core/valid/conventions.html#contexts)), but locals are defined with variable names in the current version of this interpreter, so it was left as is.
```haskell
data Context = Context {
    ...
    locals :: [ValType],
    localsMap :: [String]
    -- ^ localsMap is a stack of variable names, 
    --   the types are defined in 'locals'
    ...
}
```